### PR TITLE
Add getImageUriSize prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export default class ImageTransformer extends React.Component {
         resizeMode: PropTypes.string,
         errorComponent: PropTypes.func,
         onLayout: PropTypes.func,
+        getImageUriSize: PropTypes.func,
     };
 
     static defaultProps = {
@@ -196,7 +197,8 @@ export default class ImageTransformer extends React.Component {
         }
 
         if (uri) {
-            Image.getSize(
+            const getImageUriSize = this.props.getImageUriSize || Image.getSize;
+            getImageUriSize(
                 uri,
                 (width, height) => {
                     if (width && height) {


### PR DESCRIPTION
Allows the overriding the use of Image.getSize

I needed this functionality to improve performance in my app where the images may already be in a local cache (and also require headers to retreive).  If you are happy with it I'd also like to open a follow up PR for the `react-native-gallery-swiper` library.